### PR TITLE
core: the timeout should be bigger not lower

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-log"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Vincent <vincenzopalazzo@member.fsf.org>"]
 description = "A common library for OpenTelemetry logging in Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 authors = ["Vincent <vincenzopalazzo@member.fsf.org>"]
 description = "A common library for OpenTelemetry logging in Rust."
 license = "GPL-2.0"
-repository = "https://github.com/vincent/opentelemetry-log"
+repository = "https://github.com/vincenzopalazzo/opentelemetry-log"
 documentation = "https://docs.rs/opentelemetry-common"
-homepage = "https://github.com/vincent/opentelemetry-log"
+homepage = "https://github.com/vincenzopalazzo/opentelemetry-log"
 keywords = ["opentelemetry", "logging", "log", "rust"]
 categories = ["development-tools"]
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -29,7 +29,7 @@ pub fn init(
 ) -> anyhow::Result<()> {
     // FIXME: make this configurable from the API level
     let batch_config = BatchConfigBuilder::default()
-        .with_max_export_timeout(Duration::from_secs(1))
+        .with_max_export_timeout(Duration::from_secs(20))
         .with_max_queue_size(10_000)
         .with_max_export_batch_size(100_000);
     let batch_config = batch_config.build();


### PR DESCRIPTION
Fixing the following log resutl

```
OpenTelemetry log error occurred. Exporter timed out after 1 seconds
``f